### PR TITLE
Replace goto statement for compatibility with Lua 5.1

### DIFF
--- a/fibonacci_heap.lua
+++ b/fibonacci_heap.lua
@@ -93,6 +93,7 @@ local function removeMinimum(n)
     if not n then return nil end
     local trees = {}
     while true do
+        local advanceN = true
 
         if trees[n.degree] then
             local t = trees[n.degree]
@@ -109,13 +110,14 @@ local function removeMinimum(n)
                 n = t
             end
 
-            goto continue
+            advanceN = false
         else
             trees[n.degree] = n
         end
 
-        n = n.next
-        ::continue::
+        if advanceN then
+          n = n.next
+        end
     end
 
     local min = n


### PR DESCRIPTION
# Purpose of this PR
This PR replaces the `goto` statement so that it can be used in Lua 5.1 environments.

# Rationale
The `goto` statement was only introduced in Lua 5.2, which means this library cannot be used in Lua 5.1 environments (such as in World of Warcraft addons) without the changes in this PR.